### PR TITLE
Add nodown.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,3 +196,4 @@ Not sure, if awesome or not? [Add to under consideration list](https://github.co
 - [Actiondesk](https://www.actiondesk.io/) - Mixes the ease and flexibility of a spreadsheet with the power of a BI tool.
 - [Smartsheet](https://www.smartsheet.com/) - Get more work done with workflow, formulars and automations.
 - [Voiceflow](https://www.voiceflow.com/) - Voiceflow helps prototype and launch conversational apps.
+- [Nodown](https://nodown.io) - Nodown helps monitoring the status of your website or web app by telling you if your website goes down


### PR DESCRIPTION
Suggest adding nodown.io to that list

As I saw that there were no monitoring tools available, I suggested adding this one. But, of course, we can add others too