### PR TITLE
add Semplice to Portfolios section

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Not sure, if awesome or not? [Add to under consideration list](https://github.co
 - [Dunked](https://dunked.com/) - Portfolio & showcase websites.
 - [Exposure](https://www.exposure.co/) - A website builder for your stories.
 - [Pixpa](https://www.pixpa.com/) - Portfolio websites for photographers and creators.
+- [Semplice](https://www.semplice.com/) - Where the designers you admire come to build their portfolio.
 
 ## Membership
 


### PR DESCRIPTION
Add Semplice portfolio builder tool to Portfolios section

**Why is this awesome?**

- Attention to detail for design-focused portfolios like webfonts, full brand control, and integrations with tools like Dribbble and Unsplash.
- Really slick visual content editor.
- It's built on Wordpress and is sold as a standalone product. So no ongoing subscriptions and you have full control over what you do with the product, including where you host it.
