### PR TITLE
Add LinkyPO to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Nocode enables programmers and non-programmers to create application software th
 - [Framer](https://www.framer.com/) - The site builder trusted by leading Fortune 500 companies.
 - [Hubspot CMS](https://www.hubspot.de/products/cms) - Easy create marketing websites without coding.
 - [Jimdo](https://www.jimdo.com/) - Start your business online, fast and easy.
+- [LinkyPO](https://linkypo.com/) - Free link-in-bio and mini-site builder with calendar booking, lead capture, lists and SEO coach for creators and small businesses.
 - [Quarkly](https://quarkly.io/) - Design tool for creating websites and web apps.
 - [Shopify](https://www.shopify.com/) - E-commerce website builder.
 - [Squarespace](https://squarespace.com/) - Professional website builder.


### PR DESCRIPTION
**Add / Change** [LinkyPO](https://linkypo.com)

**Why is this awesome?**

- Free link-in-bio + mini-site builder you build entirely without code (drag-drop blocks)
- 21 block types — calendar booking with Google/Outlook sync, lead forms, OCR lists, loyalty stamps, social embeds, etc.
- Live in production, free tier without credit card; targets creators and small businesses
- Same category as Carrd / Webflow / Wix already on the list

Disclosure: I'm the maintainer of LinkyPO. Happy to adjust description or remove if it doesn't fit.