### PR TITLE
Add PageStrike to Landing Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Nocode enables programmers and non-programmers to create application software th
 - [Landingi](https://landingi.com/) - Design, publish, connect, optimize, convert and sell with landing pages.
 - [Launchaco](https://www.launchaco.com/) - Small website builder for startups.
 - [Leadpages](https://www.leadpages.com/) - Landing pages and lead generation.
+- [PageStrike](https://pagestrike.com) - AI-generated landing pages in 2 minutes with native cash-on-delivery, 0%
+  commission, and 10+ languages including Arabic RTL.
 - [Pagewiz](https://www.pagewiz.com/) - Landing pages, integrations, campaign management and A/B testing.
 - [Shortstack](https://www.shortstack.com/) - Create unique landing pages, run social contests, send emails and analyze results.
 - [Umso](https://www.umso.com/) - The website builder for startups.

--- a/README.md
+++ b/README.md
@@ -126,8 +126,7 @@ Nocode enables programmers and non-programmers to create application software th
 - [Landingi](https://landingi.com/) - Design, publish, connect, optimize, convert and sell with landing pages.
 - [Launchaco](https://www.launchaco.com/) - Small website builder for startups.
 - [Leadpages](https://www.leadpages.com/) - Landing pages and lead generation.
-- [PageStrike](https://pagestrike.com) - AI-generated landing pages in 2 minutes with native cash-on-delivery, 0%
-  commission, and 10+ languages including Arabic RTL.
+- [PageStrike](https://pagestrike.com) - AI-generated landing pages in 2 minutes with native cash-on-delivery, 0% commission, and 10+ languages including Arabic RTL.
 - [Pagewiz](https://www.pagewiz.com/) - Landing pages, integrations, campaign management and A/B testing.
 - [Shortstack](https://www.shortstack.com/) - Create unique landing pages, run social contests, send emails and analyze results.
 - [Umso](https://www.umso.com/) - The website builder for startups.


### PR DESCRIPTION
## What this PR adds

Adds **PageStrike** to the Landing Pages section, alphabetically inserted between Leadpages and Pagewiz.

## Why it fits

PageStrike is an AI-first landing page builder. Differs from existing entries in the section:

- **Convertkit / GetResponse / Leadpages** — primarily email-marketing platforms with bolt-on landing pages. PageStrike is landing-page-first.
- **Carrd / Unbounce / Instapage** — manual builders requiring template selection + copywriting. PageStrike's AI generates the complete page (copy + photos + form) in under 2 minutes from a 1-sentence product description.

Unique differentiators not present in any other entry:
- Native cash-on-delivery checkout pipeline (MENA / Africa / SEA markets)
- 0% commission on Stripe/PayPal direct
- Native AI generation in 10+ languages including Arabic RTL

## Disclosure

I'm the founder. Submitting myself since no one else has yet. Happy to adjust wording or category placement based on your preferences.

## Checklist

- [x] Entry alphabetically placed (between Leadpages and Pagewiz)
- [x] Description ~155 chars (matches section average)
- [x] Product is live and functional (https://pagestrike.com)
- [x] No promotional fluff ("revolutionary", "best", etc.)
- [x] Format matches existing entries
