### PR TITLE
Add CollabPortals to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Nocode enables programmers and non-programmers to create application software th
 - [Betty Blocks](https://www.bettyblocks.com/) - Build Faster and Innovate Smarter with No-Code.
 - [Bubble](https://bubble.io/) - Build production-ready web apps.
 - [Builder.io](https://www.builder.io/) - Drag and drop page building using your code components.
+- [CollabPortals](https://www.collabportals.com/) - Turn your Airtable base into a branded client portal with role-based permissions and custom views.
 - [Draftbit](https://draftbit.com/) - Create, customize, and launch mobile apps visually.
 - [DronaHQ](https://dronahq.com/) - Rapidly build and deploy cloud based apps like data collection apps, online forms, online database app, business process apps, automation apps, internal tools, custom business apps.
 - [FileMaker](https://www.claris.com/filemaker/) - An application development platform to build apps like a boss.


### PR DESCRIPTION
Add [CollabPortals](https://www.collabportals.com/) to the **Apps** section, in alphabetical order between Builder.io and Draftbit.

**Why is this awesome?**

- Lets non-developers turn an Airtable base into a branded, multi-tenant client portal in minutes, no code needed.
- Adds role-based permissions, per-field access control, and custom views on top of Airtable, things Airtable's own shared views cannot do.
- Useful for service businesses, consultancies, and ops teams that already run on Airtable and need a clean external interface for clients or partners.