### PR TITLE
Add RapidNative to Apps & Internal Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Nocode enables programmers and non-programmers to create application software th
 - [Odoo](https://www.odoo.com/) - Open Source business management app builder.
 - [Oracle APEX](https://apex.oracle.com/) - Build enterprise apps 20x faster with 100x less code.
 - [Pory.io](https://pory.io/) - Build custom portals powered by Airtable data.
+- [RapidNative](https://rapidnative.com/) - AI-native mobile app builder that turns ideas, sketches, or screenshots into working React Native and Expo apps with production-ready code.
 - [Siberian CMS](https://www.siberiancms.com/) - Open Source CMS for building mobile apps on Andoid and IOS.
 - [Skuid](https://www.skuid.com/) - Create Salesforce apps faster and with less custom code.
 - [Stacker](https://stacker.ai/) - Turn your spreadsheets into applications.


### PR DESCRIPTION
## Add RapidNative

Adds [RapidNative](https://rapidnative.com/) to the **Apps & Internal Tools** section.

### What it does
AI-native mobile app builder. Describe or sketch an app, watch it build in real time, ship to App Store / Play Store. Generates production-ready React Native and Expo code that can be viewed, edited, and extended.

### Why it fits
Sits naturally next to existing mobile-focused builders in this section (Adalo, Appery.io, Appsheet, Appspotr, Draftbit, Thunkable). The AI-native generation flow is the main differentiator — input is a sketch or text description rather than drag-and-drop blocks.

Placed in alphabetical order between Pory.io and Siberian CMS.

Freemium (20 free credits to start).