### PR TITLE
Add Playcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Nocode enables programmers and non-programmers to create application software th
 - [Framer](https://www.framer.com/) - The site builder trusted by leading Fortune 500 companies.
 - [Hubspot CMS](https://www.hubspot.de/products/cms) - Easy create marketing websites without coding.
 - [Jimdo](https://www.jimdo.com/) - Start your business online, fast and easy.
+- [Playcode](https://playcode.io/ai-website-builder) - AI website and app builder with hosting, visual editing and custom domains.
 - [Quarkly](https://quarkly.io/) - Design tool for creating websites and web apps.
 - [Shopify](https://www.shopify.com/) - E-commerce website builder.
 - [Squarespace](https://squarespace.com/) - Professional website builder.


### PR DESCRIPTION
Adds Playcode to the Websites section. It matches the site-builder entries already listed there and keeps the change to one README line.

Checks:
- Added one README entry only
- Kept the existing list format
- Ran git diff --check