### PR TITLE
Add AppEasy to Apps & Internal Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Nocode enables programmers and non-programmers to create application software th
 ## Apps & Internal Tools
 
 - [Adalo](https://www.adalo.com/) - Building real apps. Fast.
+- [AppEasy](https://appeasy.studio) - Launch a branded PWA app for content creators in 5 minutes, with vertical templates, offline access, push notifications and 0% B2C fee.
 - [Appery.io](https://appery.io/) - Lowcode app platform that makes creating hybrid mobile apps, web apps, and progressive web apps easy.
 - [AppGyver - SAP Apps Builder](https://www.sap.com/products/technology-platform/low-code-app-builder.html) - Platform building apps for all form factors, including mobile, desktop, browser and TV.
 - [Appsheet](https://www.appsheet.com/) - Mobile App builder.


### PR DESCRIPTION
Adding **AppEasy** to the `## Apps & Internal Tools` section, in alphabetical order (between Adalo and Appery.io).

### What it is
AppEasy lets content creators (fitness coaches, course teachers, niche educators) launch a branded Progressive Web App in 5 minutes — pick a vertical template, customize branding, upload content. Students install the app to their home screen, get offline access + push notifications, and pay the creator on the creator's own external platform (0% B2C fee).

- Public, live, no waitlist: https://appeasy.studio
- Free 7-day trial; paid plans from $19/mo.

### Disclosure
I'm the maker of AppEasy. Thanks for maintaining the list!