### PR TITLE
Add LLMGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Nocode enables programmers and non-programmers to create application software th
 - [Arize](https://arize.com/) - AI engineering platform to develop, monitor, troubleshoot, and improve machine learning models.
 - [Botpress](https://botpress.com/) - An all-in-one platform for building AI agents powered by the latest LLMs.
 - [Dify](https://dify.ai/) - AI platform for agentic workflows, RAG pipelines, integrations, and observability.
+- [LLMGraph](https://llmgraph.ai/) - No-code visual builder for LLM/AI workflows: turn your docs and models into RAG chatbots and AI agents, then deploy each to a REST API and an embeddable chat widget in one click.
 
 ## Automation and Workflows
 


### PR DESCRIPTION
Add [LLMGraph](https://llmgraph.ai/) to the **AI Platforms** section.

**Why is this awesome?**

- No-code visual builder for LLM/AI workflows — build without writing code.
- Turns your docs and models into RAG chatbots and AI agents.
- Deploys each workflow to a REST API and an embeddable chat widget in one click.

Added as a single entry in the AI Platforms section (after Dify), matching the list's `[Name](link) - Description.` format.