### PR TITLE
Add Hellomatik to Chatbots

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Nocode enables programmers and non-programmers to create application software th
 - [Flow.ai](https://flow.ai/) - Intelligent Automation using bots.
 - [Flow XO](https://flowxo.com/) - Powerful automation product that allows you to quickly and simply build incredible chatbots that help you to communicate and engage with your customers across a wide range of different sites, applications and social media platforms.
 - [Giosg](https://www.giosg.com/) - Capture your most valuable leads and customers.
+- [Hellomatik](https://hellomatik.com/) - AI agents from company knowledge that answer, sell and book on WhatsApp, email and web.
 - [Intercom](https://www.intercom.com/) - Live chat, product tours, apps and more - build relationships with your customers.
 - [Landbot](https://landbot.io/) - Intuitive chatbot builder.
 - [Opla.ai](https://opla.ai/) - Open Chatbot builder.


### PR DESCRIPTION
Adds **Hellomatik** to Chatbots (alphabetical, after Giosg).

Hellomatik is a low-code AI agent platform that turns company knowledge into agents that answer, sell and book across WhatsApp, email and web. Matched to the existing format. Thanks!