### PR TITLE
Add Checkout Page to Membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Nocode enables programmers and non-programmers to create application software th
 
 ## Membership
 
+- [Checkout Page](https://checkoutpage.com/) - Sell memberships, subscriptions, digital products, and event tickets with checkouts on your own Stripe account.
 - [Memberspace](https://www.memberspace.com/) - Turn any part of website into members-only with just a few clicks.
 - [Memberstack](https://www.memberstack.com/) - Beautiful user logins and payments for any website.
 


### PR DESCRIPTION
Adds [Checkout Page](https://checkoutpage.com/) to the Membership section.

Checkout Page is a no-code checkout builder: sellers connect their own Stripe account and sell memberships, subscriptions, digital products, and event tickets from any website, with a customer portal where members manage their own plans. It sits in the same space as Memberspace and Memberstack in this section. There is a free plan, so it can be tried without a paid commitment.

Happy to help split out an E-commerce or Payments category if you think the list would benefit; a few existing entries would fit it too.