### PR TITLE
Add Autoposting to Automation and Workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Nocode enables programmers and non-programmers to create application software th
 - [Tray.io](https://tray.io/) - Integrate your entire stack with the leading general automation platform.
 - [Workato](https://www.workato.com/) - Workflow automation, AI, Bots and more.
 - [Zapier](https://zapier.com/) - Connect your apps and automate tasks.
+- [Autoposting](https://autoposting.ai) - AI social media manager that writes, clips, and schedules posts.
 
 ## Forms
 


### PR DESCRIPTION
Adds [Autoposting](https://autoposting.ai) under Automation and Workflows.

No-code AI social media manager: writes posts in your own voice, clips long video into short-form, builds carousels, and schedules to X, LinkedIn, Instagram, Threads and YouTube. Free tier available.

One line added, entry style matches the surrounding list.